### PR TITLE
Add commit template

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ in `.git/hooks` directory of your repository.
 - if `COMMIT_VALIDATOR_NO_JIRA` environment variable is not empty, no validation is done on JIRA refs.
 - if `COMMIT_VALIDATOR_ALLOW_TEMP` environment variable is not empty, no validation is done on `fixup!` and `squash!` commits.
 
+### Commit template
+
+You might want to use the predefined commit template in order to keep the main information under hand.
+
+For that, you have to add the following lines in your repository's gitconfig (located at `<project_root>/.gitconfig`).
+```conf
+[commit]
+    template = /path/to/git-commit-template
+```
+
 ## Getting Started with github action
 
 To enable the action simply create the .github/workflows/commit-message-validator.yml file with the following content:

--- a/git-commit-template
+++ b/git-commit-template
@@ -1,0 +1,53 @@
+type(scope): subject
+
+# Body
+
+# Footer
+
+
+## Types:
+# feat: A new feature
+# fix:  A bug fix
+# docs: Documentation only changes
+# lint: Changes that do not affect the meaning of the code (white-space,
+#       formatting, missing semicolons, etc)
+# refactor: A code change that neither fixes a bug or adds a feature
+# test: Adding missing tests or correcting existing tests
+# chore: Changes to the build process or auxiliary tools and libraries such as
+#        distribution generation
+
+## Scope
+# The scope could be anything specifying place of the commit change.
+# For example `notification', 'dropdown', etc. The scope must be written in
+# kebab-case.
+
+## Subject
+# A brief but meaningfull description of the change. Here are some
+# recommandation for writing your subject:
+# - use the imperative, present tense: "change" not "changed" nor "changes"
+# - don't capitalize first letter
+# - no "." (dot) at the end
+
+## Body
+# The body should include the motivation for the change and contrast this with
+# previous behavior.
+# It is optional but highly recommended for any impacting changes.
+
+## Footer
+# The footer should contain any information about Breaking Changes and is also
+# the place to reference JIRA ticket related to this commit.
+# The footer is optional but for feat and fix type the JIRA reference is
+# mandatory.
+# The breaking changes must be at the end of the commit with only "BROKEN:"
+# before the list of breaking changes. They must be each on a new line.
+
+## Example
+# feat(toto-service): provide toto for all
+#
+# Before we had to do another thing. There was this and this problem.
+# Now, by using "toto", it's simpler and the problems are managed.
+#
+# LUM-3462
+# BROKEN:
+# first thing broken
+# second thing broken


### PR DESCRIPTION
This adds a commit template for an easier respect of the rules.

I based all the comments in the template on the README.