### PR TITLE
feat(revert): allow to not specify the reverted commit sha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ in `.git/hooks` directory of your repository.
   no validation is done on JIRA refs.
 - if `COMMIT_VALIDATOR_ALLOW_TEMP` environment variable is not empty,
   no validation is done on `fixup!` and `squash!` commits.
+- if `COMMIT_VALIDATOR_NO_REVERT_SHA1` environment variable is not empty,
+  no validation is done revert commits.
 
 ### Commit template
 
@@ -276,6 +278,8 @@ jobs:
 - if `no_jira` is not empty, no validation is done on JIRA refs.
 - if `allow_temp` is not empty, no validation is done on `fixup!`
   and `squash!` commits.
+- if `no_revert_sha1` is not empty, no validation is done on revert
+  commits.
 
 ## Add pre-commit plugin
 
@@ -303,9 +307,10 @@ Then run `pre-commit install --hook-type commit-msg` to install the
 
 ### Pre commit hook options
 
-- if `no_jira` is set, no validation is done on JIRA refs.
-- if `allow_temp` is set, no validation is done on `fixup!` and `squash!`
+- if `no-jira` is set, no validation is done on JIRA refs.
+- if `allow-temp` is set, no validation is done on `fixup!` and `squash!`
   commits.
+- if `no-revert-sha1` is set, no validation is done on revert commits.
 
 <!-- ROADMAP -->
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   allow_temp:
     description: 'If not empty, no validation is done on `fixup!` and `squash!` commits.'
     required: false
+  no_revert_sha1:
+    description: 'If not empty, reverted sha1 commit is not mandatory in revert commit message.'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -31,4 +34,5 @@ runs:
       env:
         COMMIT_VALIDATOR_NO_JIRA: ${{ inputs.no_jira }}
         COMMIT_VALIDATOR_ALLOW_TEMP: ${{ inputs.allow_temp }}
+        COMMIT_VALIDATOR_NO_REVERT_SHA1: ${{ inputs.no_revert_sha1 }}
       shell: bash

--- a/check_message.sh
+++ b/check_message.sh
@@ -10,11 +10,13 @@ OPTIONS=$(getopt --long no-jira allow-temp -- "$@")
 
 COMMIT_VALIDATOR_ALLOW_TEMP=
 COMMIT_VALIDATOR_NO_JIRA=
+COMMIT_VALIDATOR_NO_REVERT_SHA1=
 
 while true; do
   case "$1" in
     --no-jira ) COMMIT_VALIDATOR_NO_JIRA=1; shift ;;
     --allow-temp ) COMMIT_VALIDATOR_ALLOW_TEMP=1; shift ;;
+    --no-revert-sha1 ) COMMIT_VALIDATOR_NO_REVERT_SHA1=1; shift ;;
     -- ) shift; break ;;
     * ) break ;;
   esac
@@ -44,7 +46,10 @@ fi
 
 # print message so you don't lose it in case of errors
 # (in case you are not using `-m` option)
-echo "Options: JIRA=$COMMIT_VALIDATOR_NO_JIRA, TEMP=$COMMIT_VALIDATOR_ALLOW_TEMP"
+echo "Options: "
+echo "  JIRA=$COMMIT_VALIDATOR_NO_JIRA"
+echo "  TEMP=$COMMIT_VALIDATOR_ALLOW_TEMP"
+echo "  NO_REVERT_SHA1=$COMMIT_VALIDATOR_NO_REVERT_SHA1"
 printf "checking commit message:\n\n#BEGIN#\n%s\n#END#\n\n" "$MESSAGE"
 
 validate "$MESSAGE"

--- a/validator.bats
+++ b/validator.bats
@@ -472,6 +472,8 @@ LUM-2345'
 
   run validate_revert "$MESSAGE"
   [[ "$status" -eq $ERROR_REVERT ]]
+  COMMIT_VALIDATOR_NO_REVERT_SHA1= run validate_revert "$MESSAGE"
+  [[ "$status" -eq $ERROR_REVERT ]]
 }
 
 @test "revert body with commit sha1 should be valid" {
@@ -482,6 +484,17 @@ This reverts commit 1234567890.
 LUM-2345'
 
   run validate_revert "$MESSAGE"
+  [[ "$status" -eq 0 ]]
+  COMMIT_VALIDATOR_NO_REVERT_SHA1= run validate_revert "$MESSAGE"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "revert body without sha1 should be valid with the flag" {
+  MESSAGE='rerer
+
+LUM-2345'
+
+  COMMIT_VALIDATOR_NO_REVERT_SHA1=1 run validate_revert "$MESSAGE"
   [[ "$status" -eq 0 ]]
 }
 

--- a/validator.sh
+++ b/validator.sh
@@ -242,6 +242,10 @@ validate_revert() {
   local LINE=""
   local REVERTED_COMMIT=""
 
+  if [[ ! -z "${COMMIT_VALIDATOR_NO_REVERT_SHA1:-}" ]]; then
+    exit 0
+  fi
+
   while IFS= read -r LINE ;
   do
     if [[ $LINE =~ $REVERT_COMMIT_PATTERN ]]; then


### PR DESCRIPTION
With github revert no sha1 is specified, thus we don't the validator to
fail on this revert.