### PR TITLE
Feat/allow for more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,9 @@ Then run `pre-commit install --hook-type commit-msg` to install the
 - if `allow-temp` is set, no validation is done on `fixup!` and `squash!`
   commits.
 - if `no-revert-sha1` is set, no validation is done on revert commits.
+- if `--jira-in-header` jira reference can be put in the commit header.
+- `--header-length` allow to override the max length of the header line.
+- `--jira-types` takes a space separated list `"feat fix"` as a parameter to override the default types requiring a jira
 
 <!-- ROADMAP -->
 

--- a/check_message.sh
+++ b/check_message.sh
@@ -2,21 +2,19 @@
 
 set -eu
 
-OPTIONS=$(getopt --long no-jira allow-temp -- "$@")
-[ $? -eq 0 ] || {
-    echo "Incorrect options provided"
-    exit 1
-}
+OPTIONS=$(getopt --long no-jira,allow-temp,jira-in-header,header-length:,jira-types: -- "$@")
 
-COMMIT_VALIDATOR_ALLOW_TEMP=
-COMMIT_VALIDATOR_NO_JIRA=
-COMMIT_VALIDATOR_NO_REVERT_SHA1=
+unset COMMIT_VALIDATOR_ALLOW_TEMP COMMIT_VALIDATOR_NO_JIRA COMMIT_VALIDATOR_NO_REVERT_SHA1 GLOBAL_JIRA_IN_HEADER GLOBAL_MAX_LENGTH GLOBAL_JIRA_TYPES
 
+eval set -- $OPTIONS
 while true; do
   case "$1" in
     --no-jira ) COMMIT_VALIDATOR_NO_JIRA=1; shift ;;
     --allow-temp ) COMMIT_VALIDATOR_ALLOW_TEMP=1; shift ;;
     --no-revert-sha1 ) COMMIT_VALIDATOR_NO_REVERT_SHA1=1; shift ;;
+    --jira-in-header ) GLOBAL_JIRA_IN_HEADER=1; shift ;;
+    --header-length ) GLOBAL_MAX_LENGTH="$2"; shift 2 ;;
+    --jira-types ) GLOBAL_JIRA_TYPES="$2"; shift 2 ;;
     -- ) shift; break ;;
     * ) break ;;
   esac
@@ -47,9 +45,9 @@ fi
 # print message so you don't lose it in case of errors
 # (in case you are not using `-m` option)
 echo "Options: "
-echo "  JIRA=$COMMIT_VALIDATOR_NO_JIRA"
-echo "  TEMP=$COMMIT_VALIDATOR_ALLOW_TEMP"
-echo "  NO_REVERT_SHA1=$COMMIT_VALIDATOR_NO_REVERT_SHA1"
+echo "  JIRA=${COMMIT_VALIDATOR_NO_JIRA:-}"
+echo "  TEMP=${COMMIT_VALIDATOR_ALLOW_TEMP:-}"
+echo "  NO_REVERT_SHA1=${COMMIT_VALIDATOR_NO_REVERT_SHA1:-}"
 printf "checking commit message:\n\n#BEGIN#\n%s\n#END#\n\n" "$MESSAGE"
 
 validate "$MESSAGE"

--- a/validator.bats
+++ b/validator.bats
@@ -97,6 +97,18 @@ ABC-1234"
   [[ $GLOBAL_FOOTER == "" ]]
 }
 
+@test "structure: valid commit message with JIRA in header" {
+  COMMIT="feat(abc): ABC-1234
+
+plop"
+
+  GLOBAL_JIRA_IN_HEADER="allow" validate_overall_structure "$COMMIT"
+  [[ $GLOBAL_HEADER == "feat(abc): ABC-1234" ]]
+  [[ $GLOBAL_JIRA == "ABC-1234" ]]
+  [[ $GLOBAL_BODY == "plop"$'\n' ]]
+  [[ $GLOBAL_FOOTER == "" ]]
+}
+
 @test "structure: valid commit message with header and multiple JIRA" {
   COMMIT="plop plop
 

--- a/validator.bats
+++ b/validator.bats
@@ -499,23 +499,23 @@ LUM-2345'
 }
 
 @test "features and fixes commits need jira reference" {
-  [[ `need_jira "feat"` -eq 1 ]]
-  [[ `need_jira "fix"` -eq 1 ]]
+  need_jira "feat"
+  need_jira "fix"
 }
 
 @test "features and fixes commits need jira reference if env empty" {
-  [[ `COMMIT_VALIDATOR_NO_JIRA= need_jira "feat"` -eq 1 ]]
-  [[ `COMMIT_VALIDATOR_NO_JIRA= need_jira "fix"` -eq 1 ]]
+  COMMIT_VALIDATOR_NO_JIRA= need_jira "feat"
+  COMMIT_VALIDATOR_NO_JIRA= need_jira "fix"
 }
 
 @test "features and fixes commits don't need jira reference if env non empty" {
-  [[ `COMMIT_VALIDATOR_NO_JIRA=1 need_jira "feat"` -eq 0 ]]
-  [[ `COMMIT_VALIDATOR_NO_JIRA=1 need_jira "fix"` -eq 0 ]]
+  ! COMMIT_VALIDATOR_NO_JIRA=1 need_jira "feat"
+  ! COMMIT_VALIDATOR_NO_JIRA=1 need_jira "fix"
 }
 
 @test "other commits don't need jira reference" {
-  [[ `need_jira "docs"` -eq 0 ]]
-  [[ `need_jira "test"` -eq 0 ]]
+  ! need_jira "docs"
+  ! need_jira "test"
 }
 
 @test "feat without jira ref should be rejected" {

--- a/validator.bats
+++ b/validator.bats
@@ -328,6 +328,10 @@ BROKEN:
   [ "$status" -eq $ERROR_HEADER_LENGTH ]
 }
 
+@test "header length cannot be more than 150 with spaces. overriden" {
+  GLOBAL_MAX_LENGTH=150 validate_header_length "012345678 012345678 012345678 012345678 012345678 012345678 012345678 1"
+}
+
 @test "header length can be 70" {
   run validate_header_length "0123456789012345678901234567890123456789012345678901234567890123456789"
   [ "$status" -eq 0 ]

--- a/validator.sh
+++ b/validator.sh
@@ -8,7 +8,8 @@ readonly HEADER_PATTERN="^([^\(]+)\(([^\)]+)\): (.+)$"
 readonly TYPE_PATTERN="^(feat|fix|docs|gen|lint|refactor|test|chore)$"
 readonly SCOPE_PATTERN="^([a-z][a-z0-9]*)(-[a-z0-9]+)*$"
 readonly SUBJECT_PATTERN="^([a-z0-9].*[^ ^\.])$"
-readonly JIRA_PATTERN="^([A-Z]{2,4}-[0-9]{1,6} ?)+$"
+readonly JIRA_PATTERN="^([A-Z]{3,4}-[0-9]{1,6} ?)+$"
+readonly JIRA_HEADER_PATTERN="^.*([A-Z]{3,4}-[0-9]{1,6}).*$"
 readonly BROKE_PATTERN="^BROKEN:$"
 readonly TRAILING_SPACE_PATTERN=" +$"
 readonly REVERT_HEADER_PATTERN="^[R|r]evert[: ].*$"
@@ -29,9 +30,12 @@ readonly ERROR_REVERT=10
 GLOBAL_HEADER=""
 GLOBAL_BODY=""
 GLOBAL_JIRA=""
+GLOBAL_FOOTER=""
+
+# Overridable variables
 GLOBAL_JIRA_TYPES="${GLOBAL_JIRA_TYPES:-feat fix}"
 GLOBAL_MAX_LENGTH="${GLOBAL_MAX_LENGTH:-70}"
-GLOBAL_FOOTER=""
+GLOBAL_JIRA_IN_HEADER="${GLOBAL_JIRA_IN_HEADER:-}"
 
 GLOBAL_TYPE=""
 GLOBAL_SCOPE=""
@@ -54,6 +58,9 @@ validate_overall_structure() {
     if [[ $STATE -eq $WAITING_HEADER ]]; then
       GLOBAL_HEADER="$LINE"
       STATE="$WAITING_EMPTY"
+      if [[ -n "${GLOBAL_JIRA_IN_HEADER:-}" ]] && [[ $LINE =~ $JIRA_HEADER_PATTERN ]]; then
+        GLOBAL_JIRA=${BASH_REMATCH[1]}
+      fi
 
     elif [[ $STATE -eq $WAITING_EMPTY ]]; then
       if [[ $LINE != "" ]]; then

--- a/validator.sh
+++ b/validator.sh
@@ -5,7 +5,7 @@ if [[ -v ZSH_NAME ]]; then
 fi
 
 readonly HEADER_PATTERN="^([^\(]+)\(([^\)]+)\): (.+)$"
-readonly TYPE_PATTERN="^(feat|fix|docs|lint|refactor|test|chore)$"
+readonly TYPE_PATTERN="^(feat|fix|docs|gen|lint|refactor|test|chore)$"
 readonly SCOPE_PATTERN="^([a-z][a-z0-9]*)(-[a-z0-9]+)*$"
 readonly SUBJECT_PATTERN="^([a-z0-9].*[^ ^\.])$"
 readonly JIRA_PATTERN="^([A-Z]{2,4}-[0-9]{1,6} ?)+$"

--- a/validator.sh
+++ b/validator.sh
@@ -30,6 +30,7 @@ GLOBAL_HEADER=""
 GLOBAL_BODY=""
 GLOBAL_JIRA=""
 GLOBAL_JIRA_TYPES="${GLOBAL_JIRA_TYPES:-feat fix}"
+GLOBAL_MAX_LENGTH="${GLOBAL_MAX_LENGTH:-70}"
 GLOBAL_FOOTER=""
 
 GLOBAL_TYPE=""
@@ -142,12 +143,8 @@ validate_header() {
 
 validate_header_length() {
   local HEADER="$1"
-  local LENGTH
-
-  LENGTH="$(echo -n "$HEADER" | wc -c)"
-
-  if [[ $LENGTH -gt 70 ]]; then
-      echo -e "commit header length is more than 70 charaters"
+  if [[ ${#HEADER} -gt ${GLOBAL_MAX_LENGTH} ]]; then
+      echo -e "commit header length is more than ${GLOBAL_MAX_LENGTH} characters"
       exit $ERROR_HEADER_LENGTH
   fi
 }

--- a/validator.sh
+++ b/validator.sh
@@ -29,6 +29,7 @@ readonly ERROR_REVERT=10
 GLOBAL_HEADER=""
 GLOBAL_BODY=""
 GLOBAL_JIRA=""
+GLOBAL_JIRA_TYPES="${GLOBAL_JIRA_TYPES:-feat fix}"
 GLOBAL_FOOTER=""
 
 GLOBAL_TYPE=""
@@ -212,18 +213,14 @@ need_jira() {
   local TYPE=$1
 
   if [[ ! -z "${COMMIT_VALIDATOR_NO_JIRA:-}" ]]; then
-    echo 0
+    return 1
   else
-    case $TYPE in
-      feat)
-        echo 1
-        ;;
-      fix)
-        echo 1
-        ;;
-      *)
-        echo 0
-    esac
+    for type in ${GLOBAL_JIRA_TYPES}; do
+        if [[ "${TYPE}" == "${type}" ]]; then
+            return 0
+        fi
+    done
+    return 1
   fi
 }
 
@@ -231,7 +228,9 @@ validate_jira() {
   local TYPE=$1
   local JIRA=$2
 
-  if [[ "$(need_jira "$TYPE")" -eq "1" && -z "${JIRA:-}" ]]; then
+
+
+  if need_jira "$TYPE" && [[ -z "${JIRA:-}" ]]; then
      echo -e "commits with type '${TYPE}' need to include a reference to a JIRA ticket, by adding the project prefix and the issue number to the commit message, this could be done easily with: git commit -m 'feat(widget): add a wonderful widget' -m LUM-1234"
      exit $ERROR_JIRA
   fi


### PR DESCRIPTION
We can now:
- Allow for the Jira reference to be in the header
- Override the header limit
- Change the types of commit requiring a Jira

Changed some basheries as they were not optimal in the function I used, mainly
- Non posix argument handling
- Using echo instead of return and string comparison instead of return codes for instance. 

Added tests for my uses cases (one commit per change, tests included)

Didn't change the default behavior so this shouldn't break any repository.

