### PR TITLE
Forgot GitHub action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ pre-commit=./venv/bin/pre-commit
 .PHONY: lint venv
 
 venv:
-	python3.7 -m venv venv
+	python3 -m venv venv
 	$(pip) install pre-commit
 	$(pre-commit) install -t commit-msg
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ jobs:
   and `squash!` commits.
 - if `no_revert_sha1` is not empty, no validation is done on revert
   commits.
+- `jira_in_header` jira reference can be put in the commit header.
+- `header_length` allow to override the max length of the header line.
+- `jira_types` takes a space separated list `"feat fix"` as a parameter to override the default types requiring a jira
 
 ## Add pre-commit plugin
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,15 @@ inputs:
   no_revert_sha1:
     description: 'If not empty, reverted sha1 commit is not mandatory in revert commit message.'
     required: false
+  header_length:
+    description: 'If not empty, max header_length'
+    required: false
+  jira_types:
+    description: 'If not empty, space separated list of types that require Jira refs'
+    required: false
+  jira_in_header:
+    description: 'If not empty, allow for jira ref in header'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -35,4 +44,7 @@ runs:
         COMMIT_VALIDATOR_NO_JIRA: ${{ inputs.no_jira }}
         COMMIT_VALIDATOR_ALLOW_TEMP: ${{ inputs.allow_temp }}
         COMMIT_VALIDATOR_NO_REVERT_SHA1: ${{ inputs.no_revert_sha1 }}
+        GLOBAL_JIRA_TYPES: ${{ inputs.jira_types }}
+        GLOBAL_MAX_LENGTH: ${{ inputs.header_length }}
+        GLOBAL_JIRA_IN_HEADER: ${{ inputs.jira_in_header }}
       shell: bash


### PR DESCRIPTION
From my tests, github doesn't declare environment variable that don't have inputs. This allows for a clean override of the default without having to redefine them in the action. 

Tested with the following options in a test PR:
- `jira_types: feat` allow fix without jira but deny feat
- `jira_types: "feat fix"` correctly deny fix and feat without Jira ref
- nothing correctly deny fix and feat without Jira ref