### PR TITLE
feat(subject): no longer prevent commit subjects from starting with a capital letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ A brief but meaningfull description of the change.
 Here are recommandations for writing your subject:
 
 - use the imperative, present tense: "change" not "changed" nor "changes"
-- don't capitalize first letter
 - no "." (dot) at the end
 
 ### Body

--- a/git-commit-template
+++ b/git-commit-template
@@ -25,7 +25,6 @@ type(scope): subject
 # A brief but meaningful description of the change. Here are some
 # recommendation for writing your subject:
 # - use the imperative, present tense: "change" not "changed" nor "changes"
-# - don't capitalize first letter
 # - no "." (dot) at the end
 
 ## Body

--- a/validator.bats
+++ b/validator.bats
@@ -414,11 +414,6 @@ BROKEN:
   [ "$status" -eq $ERROR_SUBJECT ]
 }
 
-@test "subject cannot start with a capitalized letter" {
-  run validate_subject "Plop"
-  [ "$status" -eq $ERROR_SUBJECT ]
-}
-
 @test "subject cannot end with a point" {
   run validate_subject "plop."
   [ "$status" -eq $ERROR_SUBJECT ]
@@ -616,7 +611,7 @@ Commit about stuff\"plop \"
 LUM-2345'
 
   run validate "$MESSAGE"
-  [[ "$status" -eq $ERROR_SUBJECT ]]
+  [[ "$status" -ne $ERROR_SUBJECT ]]
 }
 
 @test "overall validation invalid body length" {

--- a/validator.sh
+++ b/validator.sh
@@ -7,7 +7,7 @@ fi
 readonly HEADER_PATTERN="^([^\(]+)\(([^\)]+)\): (.+)$"
 readonly TYPE_PATTERN="^(feat|fix|docs|gen|lint|refactor|test|chore)$"
 readonly SCOPE_PATTERN="^([a-z][a-z0-9]*)(-[a-z0-9]+)*$"
-readonly SUBJECT_PATTERN="^([a-z0-9].*[^ ^\.])$"
+readonly SUBJECT_PATTERN="^([A-Za-z0-9].*[^ ^\.])$"
 readonly JIRA_PATTERN="[A-Z]{2,6}[0-9]{0,6}-[0-9]{1,6}"
 readonly JIRA_FOOTER_PATTERN="^(${JIRA_PATTERN} ?)+$"
 readonly JIRA_HEADER_PATTERN="^.*[^A-Z](${JIRA_PATTERN}).*$"
@@ -179,7 +179,7 @@ validate_subject() {
   local SUBJECT=$1
 
   if [[ ! $SUBJECT =~ $SUBJECT_PATTERN ]]; then
-     echo -e "commit subject '$SUBJECT' should start with a lower case and not end with a '.'"
+     echo -e "commit subject '$SUBJECT' should not end with a '.'"
      exit $ERROR_SUBJECT
   fi
 }


### PR DESCRIPTION
I would like to suggest this change in order to relax the rule stating that a commit message subject must not be capitalized.

What motivates this PR is the amount of time lost when pre-commit rejects something because of a capital letter. I believe there is little value in annoying people for such reason.

My understanding is that this rule might be in place in order to make sure release notes are properly generated. If that is the reason I argue that the release notes generator should convert to lowercase to mitigate that.

With this change, the following would now be accepted:
```
chore(test): This subject message can now be capitalized
```