### PR TITLE
feat(validator): add body length parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Then run `pre-commit install --hook-type commit-msg` to install the
 - if `no-revert-sha1` is set, no validation is done on revert commits.
 - if `--jira-in-header` jira reference can be put in the commit header.
 - `--header-length` allow to override the max length of the header line.
+- `--body-length` allow to override the max length of body lines.
 - `--jira-types` takes a space separated list `"feat fix"` as a parameter to override the default types requiring a jira
 
 <!-- ROADMAP -->

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   header_length:
     description: 'If not empty, max header_length'
     required: false
+  body_length:
+    description: 'If not empty, max body_length'
+    required: false
   jira_types:
     description: 'If not empty, space separated list of types that require Jira refs'
     required: false
@@ -46,5 +49,6 @@ runs:
         COMMIT_VALIDATOR_NO_REVERT_SHA1: ${{ inputs.no_revert_sha1 }}
         GLOBAL_JIRA_TYPES: ${{ inputs.jira_types }}
         GLOBAL_MAX_LENGTH: ${{ inputs.header_length }}
+        GLOBAL_BODY_MAX_LENGTH: ${{ inputs.body_length }}
         GLOBAL_JIRA_IN_HEADER: ${{ inputs.jira_in_header }}
       shell: bash

--- a/check_message.sh
+++ b/check_message.sh
@@ -2,8 +2,8 @@
 
 set -eu
 
-OPTIONS=$(getopt --longoptions no-jira,allow-temp,jira-in-header,header-length:,jira-types: --options "" -- "$@")
-unset COMMIT_VALIDATOR_ALLOW_TEMP COMMIT_VALIDATOR_NO_JIRA COMMIT_VALIDATOR_NO_REVERT_SHA1 GLOBAL_JIRA_IN_HEADER GLOBAL_MAX_LENGTH GLOBAL_JIRA_TYPES
+OPTIONS=$(getopt --longoptions no-jira,allow-temp,jira-in-header,header-length,body-length:,jira-types: --options "" -- "$@")
+unset COMMIT_VALIDATOR_ALLOW_TEMP COMMIT_VALIDATOR_NO_JIRA COMMIT_VALIDATOR_NO_REVERT_SHA1 GLOBAL_JIRA_IN_HEADER GLOBAL_MAX_LENGTH GLOBAL_BODY_MAX_LENGTH GLOBAL_JIRA_TYPES
 
 eval set -- $OPTIONS
 while true; do
@@ -13,6 +13,7 @@ while true; do
     --no-revert-sha1 ) COMMIT_VALIDATOR_NO_REVERT_SHA1=1; shift ;;
     --jira-in-header ) GLOBAL_JIRA_IN_HEADER=1; shift ;;
     --header-length ) GLOBAL_MAX_LENGTH="$2"; shift 2 ;;
+    --body-length ) GLOBAL_BODY_MAX_LENGTH="$2"; shift 2 ;;
     --jira-types ) GLOBAL_JIRA_TYPES="$2"; shift 2 ;;
     -- ) shift; break ;;
     * ) break ;;

--- a/validator.bats
+++ b/validator.bats
@@ -457,6 +457,10 @@ LUM-2345'
   [[ "$status" -eq 0 ]]
 }
 
+@test "body length cannot be more than 150 with spaces. overridden" {
+  GLOBAL_BODY_MAX_LENGTH=150 validate_body_length "012345678 012345678 012345678 012345678 012345678 012345678 012345678 1"
+}
+
 @test "body with trailing space on line should not be valid" {
   MESSAGE='pdzofjzf '
 

--- a/validator.sh
+++ b/validator.sh
@@ -36,6 +36,7 @@ GLOBAL_FOOTER=""
 # Overridable variables
 GLOBAL_JIRA_TYPES="${GLOBAL_JIRA_TYPES:-feat fix}"
 GLOBAL_MAX_LENGTH="${GLOBAL_MAX_LENGTH:-100}"
+GLOBAL_BODY_MAX_LENGTH="${GLOBAL_BODY_MAX_LENGTH:-100}"
 GLOBAL_JIRA_IN_HEADER="${GLOBAL_JIRA_IN_HEADER:-}"
 
 GLOBAL_TYPE=""
@@ -197,8 +198,8 @@ validate_body_length() {
 
     LENGTH="$(echo -n "$LINE" | wc -c)"
 
-    if [[ $LENGTH -gt 100 ]]; then
-        echo -e "body message line length is more than 100 charaters"
+    if [[ $LENGTH -gt ${GLOBAL_BODY_MAX_LENGTH} ]]; then
+        echo -e "body message line length is more than ${GLOBAL_BODY_MAX_LENGTH} characters"
         exit $ERROR_BODY_LENGTH
     fi
   done <<< "$BODY"


### PR DESCRIPTION
Adding a body length parameter because some tools (like dependabot) generate very long commit message and we might not need to restrain the length to only 100 characters