### PR TITLE
fix(validator): header-length needs a value

### DIFF
--- a/check_message.sh
+++ b/check_message.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-OPTIONS=$(getopt --longoptions no-jira,allow-temp,jira-in-header,header-length,body-length:,jira-types: --options "" -- "$@")
+OPTIONS=$(getopt --longoptions no-jira,allow-temp,jira-in-header,header-length:,body-length:,jira-types: --options "" -- "$@")
 unset COMMIT_VALIDATOR_ALLOW_TEMP COMMIT_VALIDATOR_NO_JIRA COMMIT_VALIDATOR_NO_REVERT_SHA1 GLOBAL_JIRA_IN_HEADER GLOBAL_MAX_LENGTH GLOBAL_BODY_MAX_LENGTH GLOBAL_JIRA_TYPES
 
 eval set -- $OPTIONS


### PR DESCRIPTION
**BUG FIX**
Without specifying `:` we tell `getopt` this option doesn't need a value, hence breaking the script:
```
getopt: option `--header-length' doesn't allow an argument
```

Example use-case from infra repo:
https://github.com/lumapps/infra/blob/master/.pre-commit-config.yaml#L107

**NOTE**
You might experience this only with recent version of getopt (especially if you're MacOS user and install the newer version)