### PR TITLE
feat(action): display errors in both stdout and github summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Validation
       run: |
         ${{ github.action_path }}/check.sh \
-        ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} >> $GITHUB_STEP_SUMMARY
+        ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | tee -a $GITHUB_STEP_SUMMARY
       env:
         COMMIT_VALIDATOR_NO_JIRA: ${{ inputs.no_jira }}
         COMMIT_VALIDATOR_ALLOW_TEMP: ${{ inputs.allow_temp }}


### PR DESCRIPTION
Display errors not just in github summary but also in stdout (less confusing when you are looking at the job and not the workflow summary)