### PR TITLE
fix(validator): fix revert header pattern typo

### DIFF
--- a/validator.sh
+++ b/validator.sh
@@ -7,7 +7,7 @@ readonly JIRA_FOOTER_PATTERN="^(${JIRA_PATTERN} ?)+$"
 readonly JIRA_HEADER_PATTERN="^.*[^A-Z](${JIRA_PATTERN}).*$"
 readonly BROKE_PATTERN="^BROKEN:$"
 readonly TRAILING_SPACE_PATTERN=" +$"
-readonly REVERT_HEADER_PATTERN="^[R|r](evert|apply)[: ].*$"
+readonly REVERT_HEADER_PATTERN="^[Rr](evert|eapply)[: ].*$"
 readonly REVERT_COMMIT_PATTERN="^This reverts commit ([a-f0-9]+)"
 readonly TEMP_HEADER_PATTERN="^(fixup!|squash!).*$"
 


### PR DESCRIPTION
Two bugs in `REVERT_HEADER_PATTERN`:
- `[R|r]` matched literal `|`, changed to `[Rr]`
- 'apply' matched `rapply` instead of `reapply`, changed to `eapply`