### PR TITLE
fix: solve macos compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,5 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Unit tests on Validator
-      run: bats ./validator.bats
+    - name: Unit tests
+      run: bats ./*.bats

--- a/check.bats
+++ b/check.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO=$(mktemp -d)
+  SCRIPT="$BATS_TEST_DIRNAME/check.sh"
+  git -C "$REPO" init -q
+  git -C "$REPO" config user.email "test@test.com"
+  git -C "$REPO" config user.name "Test"
+  # base commit to anchor the range
+  git -C "$REPO" commit --allow-empty -q -m "chore(init): initial commit"
+  BASE=$(git -C "$REPO" rev-parse HEAD)
+  export REPO BASE SCRIPT
+}
+
+teardown() {
+  rm -rf "$REPO"
+}
+
+@test "check: accepts range with valid commits" {
+  git -C "$REPO" commit --allow-empty -q -m "feat(widget): add widget"
+  run env COMMIT_VALIDATOR_NO_JIRA=1 bash -c "cd '$REPO' && bash '$SCRIPT' '$BASE..HEAD'"
+  [ "$status" -eq 0 ]
+}
+
+@test "check: rejects range containing invalid commit" {
+  git -C "$REPO" commit --allow-empty -q -m "bad commit message"
+  run env COMMIT_VALIDATOR_NO_JIRA=1 bash -c "cd '$REPO' && bash '$SCRIPT' '$BASE..HEAD'"
+  [ "$status" -ne 0 ]
+}
+
+@test "check: empty range succeeds" {
+  run env COMMIT_VALIDATOR_NO_JIRA=1 bash -c "cd '$REPO' && bash '$SCRIPT' '$BASE..$BASE'"
+  [ "$status" -eq 0 ]
+}

--- a/check_message.bats
+++ b/check_message.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMPFILE=$(mktemp)
+  SCRIPT="$BATS_TEST_DIRNAME/check_message.sh"
+}
+
+teardown() {
+  rm -f "$TMPFILE"
+}
+
+@test "check_message: skips MERGE_MSG path" {
+  echo "Merge branch 'foo' into 'bar'" > "$TMPFILE"
+  run bash "$SCRIPT" "/some/path/MERGE_MSG"
+  [ "$status" -eq 0 ]
+}
+
+@test "check_message: skips message starting with 'merge'" {
+  echo "Merge branch 'foo' into 'bar'" > "$TMPFILE"
+  run bash "$SCRIPT" "$TMPFILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "check_message: skips message starting with 'Merge' (capital)" {
+  echo "Merge pull request #1" > "$TMPFILE"
+  run bash "$SCRIPT" "$TMPFILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "check_message: strips comment lines before validating" {
+  printf "# This is a comment\nfeat(scope): valid subject\n" > "$TMPFILE"
+  run bash "$SCRIPT" --no-jira "$TMPFILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "check_message: accepts valid commit message" {
+  echo "feat(widget): add a wonderful widget" > "$TMPFILE"
+  run bash "$SCRIPT" --no-jira "$TMPFILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "check_message: rejects invalid commit message" {
+  echo "this is not valid" > "$TMPFILE"
+  run bash "$SCRIPT" --no-jira "$TMPFILE"
+  [ "$status" -ne 0 ]
+}
+
+@test "check_message: --jira-types=feat requires JIRA for feat commits" {
+  echo "feat(widget): add a wonderful widget" > "$TMPFILE"
+  run bash "$SCRIPT" --jira-types=feat "$TMPFILE"
+  [ "$status" -ne 0 ]
+}
+
+@test "check_message: --jira-types=feat does not require JIRA for fix commits" {
+  echo "fix(widget): correct a bug" > "$TMPFILE"
+  run bash "$SCRIPT" --jira-types=feat "$TMPFILE"
+  [ "$status" -eq 0 ]
+}

--- a/check_message.sh
+++ b/check_message.sh
@@ -2,11 +2,9 @@
 
 set -eu
 
-OPTIONS=$(getopt --longoptions no-jira,allow-temp,jira-in-header,header-length:,body-length:,jira-types: --options "" -- "$@")
 unset COMMIT_VALIDATOR_ALLOW_TEMP COMMIT_VALIDATOR_NO_JIRA COMMIT_VALIDATOR_NO_REVERT_SHA1 GLOBAL_JIRA_IN_HEADER GLOBAL_MAX_LENGTH GLOBAL_BODY_MAX_LENGTH GLOBAL_JIRA_TYPES
 
-eval set -- $OPTIONS
-while true; do
+while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-jira ) COMMIT_VALIDATOR_NO_JIRA=1; shift ;;
     --allow-temp ) COMMIT_VALIDATOR_ALLOW_TEMP=1; shift ;;

--- a/check_message.sh
+++ b/check_message.sh
@@ -10,8 +10,11 @@ while [[ $# -gt 0 ]]; do
     --allow-temp ) COMMIT_VALIDATOR_ALLOW_TEMP=1; shift ;;
     --no-revert-sha1 ) COMMIT_VALIDATOR_NO_REVERT_SHA1=1; shift ;;
     --jira-in-header ) GLOBAL_JIRA_IN_HEADER=1; shift ;;
+    --header-length=* ) GLOBAL_MAX_LENGTH="${1#*=}"; shift ;;
     --header-length ) GLOBAL_MAX_LENGTH="$2"; shift 2 ;;
+    --body-length=* ) GLOBAL_BODY_MAX_LENGTH="${1#*=}"; shift ;;
     --body-length ) GLOBAL_BODY_MAX_LENGTH="$2"; shift 2 ;;
+    --jira-types=* ) GLOBAL_JIRA_TYPES="${1#*=}"; shift ;;
     --jira-types ) GLOBAL_JIRA_TYPES="$2"; shift 2 ;;
     -- ) shift; break ;;
     * ) break ;;


### PR DESCRIPTION
## Issue
Using the validator returns the following error in MacOS system

```sh
Commit Message Validator.................................................Failed
- hook id: commit-message-validator
- exit code: 1

sed: no-jira,allow-temp,jira-in-header,header-length:,body-length:,jira-types:: No such file or directory

```


## Changes
Replace getopt by a loop on args