### PR TITLE
chore(validator): use bash regex builtin instead of grep / wc

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -5,13 +5,12 @@ set -eu
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $DIR/validator.sh
 
-COMMITS=`git log --no-merges --pretty="%H" --no-decorate $1`
-
+git log --no-merges --pretty="%H" --no-decorate $1 |
 while IFS= read -r COMMIT
 do
    MESSAGE=`git log -1 --pretty='%B' $COMMIT`
    echo "checking commit ${COMMIT}..."
    validate "$MESSAGE"
-done <<< $COMMITS
+done
 
 echo "All commits successfully checked"

--- a/validator.sh
+++ b/validator.sh
@@ -186,8 +186,7 @@ validate_body_length() {
   while IFS= read -r LINE ;
   do
     # Skip lines with no spaces as they can't be split
-    $(echo -n "$LINE" | grep -q "\s") || continue
-
+    [[ ! "$LINE" =~ [[:space:]] ]] && continue
 
     if [[ "${#LINE}" -gt ${GLOBAL_BODY_MAX_LENGTH} ]]; then
         echo -e "body message line length is more than ${GLOBAL_BODY_MAX_LENGTH} characters"

--- a/validator.sh
+++ b/validator.sh
@@ -188,11 +188,8 @@ validate_body_length() {
     # Skip lines with no spaces as they can't be split
     $(echo -n "$LINE" | grep -q "\s") || continue
 
-    local LENGTH
 
-    LENGTH="$(echo -n "$LINE" | wc -c)"
-
-    if [[ $LENGTH -gt ${GLOBAL_BODY_MAX_LENGTH} ]]; then
+    if [[ "${#LINE}" -gt ${GLOBAL_BODY_MAX_LENGTH} ]]; then
         echo -e "body message line length is more than ${GLOBAL_BODY_MAX_LENGTH} characters"
         exit $ERROR_BODY_LENGTH
     fi


### PR DESCRIPTION
This avoids running a sub-shell, which becomes slow over large number of commits / lines.

Also run pipe the initial `git log --oneline` directly into `while read`, a variable makes no sense either here.