### PR TITLE
chore(check-message): fix issues with bash version < 4.0

### DIFF
--- a/check_message.bats
+++ b/check_message.bats
@@ -27,6 +27,18 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "check_message: skips message starting with 'MERGE' (all caps)" {
+  echo "MERGE branch 'feature' into 'main'" > "$TMPFILE"
+  run bash "$SCRIPT" "$TMPFILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "check_message: skips message starting with 'MeRgE' (mixed case)" {
+  echo "MeRgE branch 'test'" > "$TMPFILE"
+  run bash "$SCRIPT" "$TMPFILE"
+  [ "$status" -eq 0 ]
+}
+
 @test "check_message: strips comment lines before validating" {
   printf "# This is a comment\nfeat(scope): valid subject\n" > "$TMPFILE"
   run bash "$SCRIPT" --no-jira "$TMPFILE"

--- a/check_message.sh
+++ b/check_message.sh
@@ -35,8 +35,8 @@ fi
 # removing comment lines from message
 MESSAGE=$(sed '/^#/d' "$1")
 
-FIRST_WORD=${MESSAGE%% *}
-if [[ "${FIRST_WORD,,}" == merge ]]
+FIRST_WORD=$(echo "${MESSAGE%% *}" | tr '[:upper:]' '[:lower:]')
+if [[ "${FIRST_WORD}" == merge ]]
 then
    # ignore merge commits (merge after conflict resolution)
   exit


### PR DESCRIPTION
The ${var,,} syntax requires bash 4+, but macOS typically ships with bash 3.x replace with the portable tr command that works across all bash versions